### PR TITLE
fix named export not found error

### DIFF
--- a/src/use-places-autocomplete.ts
+++ b/src/use-places-autocomplete.ts
@@ -1,6 +1,7 @@
 import type { Ref } from 'vue'
 import { onMounted, reactive, toRefs, watch } from 'vue'
-import { Loader } from '@googlemaps/js-api-loader'
+import pkg from '@googlemaps/js-api-loader';
+const { Loader } = pkg;
 import { debounce as debounceFn } from 'perfect-debounce'
 import type { AutocompletionRequest, GooglePlacesAutocompleteOptions } from './types'
 import autocompletionRequestBuilder from './helpers/autocompletionRequestBuilder'


### PR DESCRIPTION
`import { Loader } from "@googlemaps/js-api-loader";` 

throws an error in certain conditions (i.e. testing)

> SyntaxError: Named export 'Loader' not found. The requested module '@googlemaps/js-api-loader' is a CommonJS module, which may not support all module.exports as named exports.

I've change the import to:
```
import pkg from '@googlemaps/js-api-loader';
const { Loader } = pkg;
```