### PR TITLE
feat: add places component

### DIFF
--- a/src/GooglePlacesAutocomplete.ts
+++ b/src/GooglePlacesAutocomplete.ts
@@ -1,0 +1,70 @@
+import { computed, defineComponent, ref, watch } from 'vue'
+import type { LoaderOptions } from '@googlemaps/js-api-loader'
+import { type AutocompletionRequest, type GooglePlacesAutocompleteOptions, usePlacesAutocomplete } from '.'
+
+const GooglePlacesAutocomplete = defineComponent({
+  name: 'GooglePlacesAutocomplete',
+  props: {
+    modelValue: {
+      type: String,
+      default: '',
+    },
+    apiKey: {
+      type: String,
+      default: '',
+      required: false,
+    },
+    apiOptions: {
+      type: Object as () => Partial<LoaderOptions>,
+      default: () => ({}),
+      required: false,
+    },
+    autocompletionRequest: {
+      type: Object as () => AutocompletionRequest,
+      default: () => ({}),
+      required: false,
+    },
+    debounce: {
+      type: Number,
+      default: 300,
+      required: false,
+    },
+    minLengthAutocomplete: {
+      type: Number,
+      default: 0,
+      required: false,
+    },
+    withSessionToken: {
+      type: Boolean,
+      required: false,
+    },
+  },
+  emits: ['update:modelValue', 'loadFailed'],
+  setup(props, { slots, expose, emit }) {
+    const { modelValue, ...rest } = props
+
+    const query = ref(modelValue)
+
+    const { refreshSessionToken, sessionToken, suggestions, loading } = usePlacesAutocomplete(query, {
+      ...rest,
+      onLoadFailed(error) {
+        emit('loadFailed', error)
+      },
+    })
+
+    expose({
+      refreshSessionToken,
+      getSessionToken() {
+        return sessionToken.value
+      },
+    })
+
+    watch(query, (newVal) => {
+      emit('update:modelValue', newVal)
+    })
+
+    return () => slots.default!({ suggestions: suggestions.value, loading: loading.value })
+  },
+})
+
+export default GooglePlacesAutocomplete

--- a/src/GooglePlacesAutocomplete.ts
+++ b/src/GooglePlacesAutocomplete.ts
@@ -1,11 +1,11 @@
-import { computed, defineComponent, ref, watch } from 'vue'
+import { computed, defineComponent } from 'vue'
 import type { LoaderOptions } from '@googlemaps/js-api-loader'
-import { type AutocompletionRequest, type GooglePlacesAutocompleteOptions, usePlacesAutocomplete } from '.'
+import { type AutocompletionRequest, usePlacesAutocomplete } from '.'
 
 const GooglePlacesAutocomplete = defineComponent({
   name: 'GooglePlacesAutocomplete',
   props: {
-    modelValue: {
+    query: {
       type: String,
       default: '',
     },
@@ -39,11 +39,11 @@ const GooglePlacesAutocomplete = defineComponent({
       required: false,
     },
   },
-  emits: ['update:modelValue', 'loadFailed'],
+  emits: ['loadFailed'],
   setup(props, { slots, expose, emit }) {
-    const { modelValue, ...rest } = props
+    const { query: _q, ...rest } = props
 
-    const query = ref(modelValue)
+    const query = computed(() => props.query)
 
     const { refreshSessionToken, sessionToken, suggestions, loading } = usePlacesAutocomplete(query, {
       ...rest,
@@ -57,10 +57,6 @@ const GooglePlacesAutocomplete = defineComponent({
       getSessionToken() {
         return sessionToken.value
       },
-    })
-
-    watch(query, (newVal) => {
-      emit('update:modelValue', newVal)
     })
 
     return () => slots.default!({ suggestions: suggestions.value, loading: loading.value })

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import geocodeByLatLng from './utils/geocodeByLatLng'
 import geocodeByAddress from './utils/geocodeByAddress'
 import geocodeByPlaceId from './utils/geocodeByPlaceId'
 import getLatLng from './utils/getLatLng'
+import GooglePlacesAutocomplete from './GooglePlacesAutocomplete'
 
 export {
   usePlacesAutocomplete,
@@ -10,6 +11,7 @@ export {
   geocodeByLatLng,
   geocodeByAddress,
   geocodeByPlaceId,
+  GooglePlacesAutocomplete,
 }
 
 export {


### PR DESCRIPTION
This PR adds in a renderless component for options API users:

```vue
<script setup>
import { ref } from 'vue'
import { GooglePlacesAutocomplete } from 'vue-use-places-autocomplete'

const query = ref('')

const autocompleteRef = ref(null)

// autocompleteRef.value.getSessionToken()
// autocompleteRef.value.refreshSessionToken()
</script>

<template>
  <input type="text" v-model="query" placeholder="Search a place..." />
  <GooglePlacesAutocomplete :query="query" ref="autocompleteRef" v-slot="{ suggestions, loading }">
    <Loading v-if="loading" />
    <ul v-else>
      <li v-for="item in suggestions" :key="item.place_id">{{ item.description }}</li>
    </ul>
  </GooglePlacesAutocomplete>
</template>
```