### PR TITLE
check query.value typeof

### DIFF
--- a/src/use-places-autocomplete.ts
+++ b/src/use-places-autocomplete.ts
@@ -34,6 +34,11 @@ export default function usePlacesAutocomplete(query: Ref<string>, {
       return
     }
 
+    if (typeof query.value !== 'string') {
+      state.suggestions = []
+      return
+    }
+
     if (query.value.length < minLengthAutocomplete || !query.value.length) {
       state.suggestions = []
       return


### PR DESCRIPTION
Hi,

this should be checked for typeof coz sometimes value is null and null.length causes errors in console.